### PR TITLE
Order change for navigate after login

### DIFF
--- a/src/sections/auth/login/LoginForm.js
+++ b/src/sections/auth/login/LoginForm.js
@@ -36,7 +36,6 @@ export default function LoginForm() {
     validationSchema: LoginSchema,
     onSubmit: ({email, password}) => {
       tryvestorSignIn({email, password}, navigate);
-      navigate('/dashboard/overview', { replace: true });
 
     },
   });

--- a/src/store/actions/authActions.js
+++ b/src/store/actions/authActions.js
@@ -21,6 +21,7 @@ export const tryvestorSignIn = (creds, navigate) => {
               }
               apiTryvestors.getSingle(data.user.uid).then((user) => {
                 const payload = { ...user };
+                navigate('/dashboard/overview', { replace: false });
                 dispatch({ type: 'SIGN_IN_USER', user: payload, userType});
               });
             })


### PR DESCRIPTION
Early us of navigate() (tryvestorSignIn has async functions) was causing landing page to show for a split second before actually going to dashboard. This is because navigate was too "far" (timewise) of the dispatch function that sets the userType and therefore triggers to router switch. Now, navigate happens right before the router switch and no stuttering happens. Fix was quite anticlimactic.